### PR TITLE
Make migrations installable 

### DIFF
--- a/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_image.yml
+++ b/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_image.yml
@@ -1,5 +1,6 @@
 id: ud_migrations_paragraph_intro_image
 label: 'UD dependee image migration for paragraph example'
+migration_group: ud_migrations_paragraph_group
 migration_tags:
   - UD Paragraphs Intro
   - UD Example

--- a/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_node.yml
+++ b/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_node.yml
@@ -1,5 +1,6 @@
 id: ud_migrations_paragraph_intro_node
 label: 'UD host node migration for paragraph example'
+migration_group: ud_migrations_paragraph_group
 migration_tags:
   - UD Paragraphs Intro
   - UD Example

--- a/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_paragraph.yml
+++ b/ud_migrations_paragraph_intro/config/install/migrate_plus.migration.ud_migrations_paragraph_intro_paragraph.yml
@@ -1,5 +1,6 @@
 id: ud_migrations_paragraph_intro_paragraph
 label: 'UD dependee paragraph migration for paragraph example'
+migration_group: ud_migrations_paragraph_group
 migration_tags:
   - UD Paragraphs Intro
   - UD Example

--- a/ud_migrations_paragraph_intro/config/install/migrate_plus.migration_group.ud.yml
+++ b/ud_migrations_paragraph_intro/config/install/migrate_plus.migration_group.ud.yml
@@ -1,0 +1,4 @@
+id: ud_migrations_paragraph_group
+label: UD Paragraph Example
+description: Paragraph migration example
+source_type: JSON / Paragraphs


### PR DESCRIPTION
1. Collect the paragraph migrations under a group. It lists them in the Migration UI
2. Use folder structure and file names for the migration `.yml` files that installs/import them during the module activation. 
